### PR TITLE
add: CLI (#3)

### DIFF
--- a/alphabet2kana/main.py
+++ b/alphabet2kana/main.py
@@ -5,18 +5,20 @@ from .alphabet2kana import a2k
 
 def parse_args(test=None):
     parser = argparse.ArgumentParser(
-        prog='a2k',
+        prog="a2k",
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        description="Convert English alphabet to Katakana")
-    parser.add_argument('text', metavar='text', type=str,
-                        help='Half-width English alphabet string')
-    parser.add_argument('-d', '--delimiter', type=str,
-                        metavar='char',
-                        help='Katakana delimiter')
-    parser.add_argument('-n', '--numeral', action='store_true',
-                        help='Convert Arabic numerals')
-    parser.add_argument('-V', '--version', action='version',
-                        version="0.1.4")
+        description="Convert English alphabet to Katakana",
+    )
+    parser.add_argument(
+        "text", metavar="text", type=str, help="Half-width English alphabet string"
+    )
+    parser.add_argument(
+        "-d", "--delimiter", type=str, metavar="char", help="Katakana delimiter"
+    )
+    parser.add_argument(
+        "-n", "--numeral", action="store_true", help="Convert Arabic numerals"
+    )
+    parser.add_argument("-V", "--version", action="version", version="0.1.4")
     if test:
         return parser.parse_args(test)
     else:
@@ -29,5 +31,5 @@ def main():
     print(res)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/alphabet2kana/main.py
+++ b/alphabet2kana/main.py
@@ -1,0 +1,33 @@
+import argparse
+
+from .alphabet2kana import a2k
+
+
+def parse_args(test=None):
+    parser = argparse.ArgumentParser(
+        prog='a2k',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description="Convert English alphabet to Katakana")
+    parser.add_argument('text', metavar='text', type=str,
+                        help='Half-width English alphabet string')
+    parser.add_argument('-d', '--delimiter', type=str,
+                        metavar='char',
+                        help='Katakana delimiter')
+    parser.add_argument('-n', '--numeral', action='store_true',
+                        help='Convert Arabic numerals')
+    parser.add_argument('-V', '--version', action='version',
+                        version="0.1.4")
+    if test:
+        return parser.parse_args(test)
+    else:
+        return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    res = a2k(args.text, delimiter=args.delimiter, numeral=args.numeral)
+    print(res)
+
+
+if __name__ == '__main__':
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,3 +16,6 @@ black = "^20.8b1"
 [build-system]
 requires = ["poetry>=0.12"]
 build-backend = "poetry.masonry.api"
+
+[tool.poetry.scripts]
+a2k = 'alphabet2kana.main:main'


### PR DESCRIPTION
```
$ a2k こんにちは
こんにちは
$ a2k こんにちはa2k
こんにちはエー2ケー
$  a2k こんにちはa2k -n
こんにちはエーツーケー
$ a2k こんにちは☆a2k -n
こんにちは☆エーツーケー
$ a2k こんにちは☆a2k -n -d ☆
こんにちは☆エー☆ツー☆ケー
$ a2k -V
0.1.4
$ a2k -h
usage: a2k [-h] [-d char] [-n] [-V] text

Convert English alphabet to Katakana

positional arguments:
  text                  Half-width English alphabet string

optional arguments:
  -h, --help            show this help message and exit
  -d char, --delimiter char
                        Katakana delimiter
  -n, --numeral         Convert Arabic numerals
  -V, --version         show program's version number and exit
$  a2k -v
usage: a2k [-h] [-d char] [-n] [-V] text
a2k: error: the following arguments are required: text
$ a2k -B
usage: a2k [-h] [-d char] [-n] [-V] text
a2k: error: the following arguments are required: text
```