### PR TITLE
support : python 3.10, 3.11

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -11,18 +11,22 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.x'
+
     - uses: snok/install-poetry@v1
+
     - name: Install Poetry
       run: |
         python -m pip install --upgrade pip
         poetry install --no-interaction
+
     - name: Build package
       run: poetry build
+
     - name: Publish package to PyPI
       env:
         USERNAME: __token__

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,11 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
     - uses: snok/install-poetry@v1
+
+    - name: Poetry Install
+      run: |
+        poetry install --no-interaction
+
     - name: Check Format
       run: |
         poetry run isort . --check
@@ -22,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,12 +6,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
     - uses: snok/install-poetry@v1
-    - name: Install Poetry
-      run: |
-        poetry install --no-interaction
     - name: Check Format
       run: |
         poetry run isort . --check
@@ -25,31 +22,36 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+
     - name: Install Poetry
       uses: snok/install-poetry@v1
       with:
         virtualenvs-create: true
         virtualenvs-in-project: true
+
     - name: Load cached venv
       id: cached-poetry-dependencies
       uses: actions/cache@v2
       with:
         path: .venv
         key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
+
     # load cached venv if cache exists
     - name: Install Dependencies
       if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
       run: poetry install --no-interaction --no-root
+
     - name: Install Root Dependency
       run: poetry install --no-interaction
+
     - name: Run Tests
       run: |
         source .venv/bin/activate

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 HonoShirai
+Copyright (c) 2023 HonoShirai
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # alphabet2kana
 
+![PyPI - Version](https://img.shields.io/pypi/v/alphabet2kana)
+![PyPI - Python Version](https://img.shields.io/pypi/pyversions/alphabet2kana)
+
+
 Convert English alphabet to Katakana
 
 アルファベットの日本語表記は [Unidic](https://unidic.ninjal.ac.jp/) 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "alphabet2kana"
-version = "0.1.5"
+version = "0.1.6"
 description = "Convert English alphabet to Katakana"
 repository = "https://github.com/shihono/alphabet2kana"
 readme = "README.md"


### PR DESCRIPTION
python 3.9 までしか検証していなかったため、3.10以降も対応

[poetry buildコマンドで生成されるパッケージには、Pythonバージョンとライセンスに関するclassifiersが自動で生成される](https://qiita.com/yuji38kwmt/items/dbf6d20666c054d84e14) の通り調べた限り、classifier に 3.11 まで追加されるため、サポートしているかテストする。

```bash
$ poetry --version 
Poetry (version 1.6.1)
```

- update github actions version
   - `actions/checkout@v3`
   - `actions/setup-python@v4`
- drop python 3.7 
   -  poetry update: https://github.com/python-poetry/poetry/releases/tag/1.6.0
- test python 3.10, 3.11
- set new version